### PR TITLE
PKG-13926 Bump minizip-ng to 4.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "minizip" %}
-{% set version = "4.0.3" %}
+{% set version = "4.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/zlib-ng/minizip-ng/archive/{{ version }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e39a736d4f55c22fa548e68225b2e92bc22aedd9ab90d002b0c5851e3a7bdace
+  sha256: 3cc35c2cb925dbe67cc801e3234b31b0f30197812a99377352fa1b551ab3d011
 
 build:
   number: 0
@@ -36,12 +36,12 @@ requirements:
 test:
   commands:
     # presence of shared libraries
-    - test -f $PREFIX/lib/libminizip${SHLIB_EXT}        # [unix]
+    - test -f $PREFIX/lib/libminizip${SHLIB_EXT}  # [unix]
     - if not exist %LIBRARY_BIN%\libminizip.dll exit 1  # [win]
     - if not exist %LIBRARY_LIB%\libminizip.lib exit 1  # [win]
 
     # absence of static libraries
-    - test ! -f $PREFIX/lib/libminizip.a                # [unix]
+    - test ! -f $PREFIX/lib/libminizip.a  # [unix]
 
 about:
   home: https://github.com/zlib-ng/minizip-ng


### PR DESCRIPTION
## Summary
- Bump version and GitHub archive sha256 to **4.2.1**
- Minor whitespace tidy in test commands

## Testing
- [ ] CI (conda-build matrix)

Made with [Cursor](https://cursor.com)